### PR TITLE
[fix] syntax_error case can return NULL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,8 @@ SRCS = main.c \
 		get_next_line_utils.c
 
 PARCER_DIR = srcs/parser/
-PARCER_FILES = parse.c
+PARCER_FILES = parse.c \
+	parse_utils.c
 PARCER_SRCS = $(addprefix $(PARCER_DIR), $(PARCER_FILES))
 
 LEXER_DIR = srcs/lexer/
@@ -21,7 +22,8 @@ LEXER_TEST_SRCS = srcs/lexer/tester.c \
 	get_next_line_utils.c \
 	srcs/lexer/lexer.c \
 	srcs/lexer/lexer_utils.c \
-	srcs/parser/parse.c
+	srcs/parser/parse.c \
+	srcs/parser/parse_utils.c
 LEXER_TEST_OBJS = $(LEXER_TEST_SRCS:.c=.o)
 
 OBJS = $(SRCS:.c=.o)

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -90,9 +90,12 @@ struct s_node
 
 void minishell(int argc, char **argv);
 char *read_line();
-t_node *parse(t_token *tok);
 
-// lexer.c
+// srcs/parser
+t_node *parse(t_token *tok);
+void	print_node(t_node *node, int tab_n);
+
+// srcs/lexer
 t_token *lexer(char *line);
 
 // lexer_utils.c

--- a/srcs/parser/parse_utils.c
+++ b/srcs/parser/parse_utils.c
@@ -1,0 +1,49 @@
+#include "minishell.h"
+
+void	print_indent(int tab_n)
+{
+	int	cnt;
+
+	cnt = 0;
+	while (cnt++ < tab_n)
+		printf(" ");
+}
+
+void	print_node(t_node *node, int tab_n)
+{
+	int	i;
+	char	*node_type[2] = {"ND_PIPE", "ND_COMMAND"};
+
+	i = 0;
+	if (node->lhs == NULL && node->rhs == NULL)
+	{
+		print_indent(tab_n);
+		printf("node_type: %s\n", node_type[node->kind]);
+		if (node->cmd->cmd == NULL)
+			return ;
+		while (node->cmd->cmd[i] != NULL)
+		{
+			print_indent(tab_n + 2);
+			printf("node: %s\n", node->cmd->cmd[i++]);
+		}
+		if (node->cmd->redirect_in->file_name)
+		{
+			print_indent(tab_n + 4);
+			printf("redirin: %s\n", node->cmd->redirect_in->file_name);
+		}
+		if (node->cmd->redirect_out->file_name)
+		{
+			print_indent(tab_n + 4);
+			printf("redirout: %s\n", node->cmd->redirect_out->file_name);
+		}
+	}
+	if (node->lhs != NULL || node->rhs != NULL)
+	{
+		print_indent(tab_n);
+		printf("node_type: %s\n", node_type[node->kind]);
+		if (node->lhs != NULL)
+			print_node(node->lhs, tab_n+2);
+		if (node->rhs != NULL)
+			print_node(node->rhs, tab_n+2);
+	}
+}


### PR DESCRIPTION
git branchのテストも含む
syntax errorが発生した際にリソースをfreeし、NULLが返るように変更。
syntax_errorはparse()内で全て確認するように変更
print_nodeを別ファイルに切り分けた。