### PR TITLE
Shongou

### DIFF
--- a/srcs/builtins/ft_env.c
+++ b/srcs/builtins/ft_env.c
@@ -1,0 +1,25 @@
+#include "minishell.h"
+
+//envp is temporary placement, replace environ later
+void	ft_env(char **strs, char *envp[])
+{
+	int	i;
+
+	if (strs[1])
+	{
+		ft_putstr_fd("env: does not support arguments", 2);
+		return ;
+	}
+	i = 0;
+	while (envp[i])
+	{
+		ft_putstr_fd(envp[i++], 1);
+		ft_putstr_fd("\n", 1);
+	}
+}
+
+int main(int argc, char **argv, char *envp[])
+{
+	char	*strs[2] = {"env"};
+	ft_env(strs, envp);
+}

--- a/srcs/builtins/ft_env.c
+++ b/srcs/builtins/ft_env.c
@@ -1,25 +1,28 @@
 #include "minishell.h"
 
-//envp is temporary placement, replace environ later
-void	ft_env(char **strs, char *envp[])
+void	ft_env(char **strs, t_env *envp)
 {
-	int	i;
-
 	if (strs[1])
 	{
-		ft_putstr_fd("env: does not support arguments", 2);
+		ft_putstr_fd("env: does not support arguments\n", 2);
 		return ;
 	}
-	i = 0;
-	while (envp[i])
-	{
-		ft_putstr_fd(envp[i++], 1);
-		ft_putstr_fd("\n", 1);
-	}
+	print_env(envp);
 }
 
-int main(int argc, char **argv, char *envp[])
+int main(void)
 {
 	char	*strs[2] = {"env"};
-	ft_env(strs, envp);
+	t_env *environ;
+
+	environ	= create_env();
+	ft_env(strs, environ);
+	printf("\n\n");
+	{
+	char	*strs[3] = {"env", "abc"};
+
+	environ	= create_env();
+	ft_env(strs, environ);
+	}
+	return (0);
 }

--- a/srcs/builtins/ft_env.c
+++ b/srcs/builtins/ft_env.c
@@ -16,7 +16,10 @@ int main(void)
 	t_env *environ;
 
 	environ	= create_env();
+	printf("\n\e[1;33m==ft_env==\e[0m\n");
 	ft_env(strs, environ);
+	printf("\n\e[1;33m==env(originator)==\e[0m\n");
+	system("env");
 	printf("\n\n");
 	{
 	char	*strs[3] = {"env", "abc"};

--- a/srcs/builtins/ft_export.c
+++ b/srcs/builtins/ft_export.c
@@ -20,34 +20,37 @@ bool	is_valid_var(char *str)
 }
 
 
-int	update_env_var(char *arg, char *envp[], int j, bool append_flag)
+//int	update_env_var(char *arg, t_env *envp, bool append_flag)
+int	update_env_var(char *arg, t_env *envp, int flag)
 {
-	char	**split_env;
+//	char	**split_env;
 	char	*equal_pos;
 	char	**split_args;
 	char	*value;
+	t_env	*target_var;
+	char	*tmp;
 
 	split_args = ft_split(arg, '='); // must free
 //	i = -1;
 //	while (envp[i++])
 //	{
-	split_env = ft_split(envp[j], '='); //must free
-	if (ft_strlen(split_args[0]) == ft_strlen(split_env[0])
-		&& ft_strncmp(split_args[0], split_env[0], ft_strlen(split_args[0])) == 0)
+//	split_env = ft_split(envp[j], '='); //must free
+//	if (ft_strlen(split_args[0]) == ft_strlen(split_env[0])
+//		&& ft_strncmp(split_args[0], split_env[0], ft_strlen(split_args[0])) == 0)
+	target_var = search_env(envp, split_args[0]);
+	if (target_var)
 	{
-		if (append_flag)
+		equal_pos = ft_strchr(arg, '=');
+		value = ft_substr(equal_pos, 1, ft_strlen(equal_pos + 1));
+		if (flag & 2)
+			target_var->value = ft_joinfree(target_var->value, value);
+		else if (flag & 1)
 		{
-			equal_pos = ft_strchr(arg, '=');
-			value = ft_substr(equal_pos, 1, ft_strlen(equal_pos + 1));
-			envp[j] = ft_strjoin(envp[j], value);
-			free(value);
-			return (1);
+			tmp = target_var->value;
+			target_var->value = value;
+			free(tmp);
 		}
-		else
-		{
-			envp[j] = arg;
-			return (1);
-		}
+		return (1);
 	}
 //	}
 	return (0);
@@ -60,50 +63,99 @@ void	print_invalid_identifier(char *str)
 	ft_putstr_fd("': not a valid identifier\n", 2);
 }
 
-void	add_var_to_env(char **strs, char **envp)
+void	push_new_env_var(char *arg, t_env *envp)
+{
+	t_env	*new;
+
+	new = (t_env *)malloc(sizeof(t_env) * 1);
+	if (new == NULL)
+		return ;
+	else
+		set_data(arg, new);
+	add_env(&envp, new);
+}
+
+int	is_append_flag(char **key, char *eq_pos)
+{
+	char	*tmp;
+
+	if (eq_pos && eq_pos != *key && *(eq_pos - 1) == '+' && *key[0] != '+')
+	{
+		*(eq_pos - 1) = '\0';
+		tmp = *key;
+		*key = ft_strjoin(*key, eq_pos);
+//		free(tmp); //The actual argument(key) is taken in malloc, so it is free.
+		return (1);
+	}
+	return (0);
+}
+
+int	which_update_flag(char **key)
+{
+	char	**split_args;
+	char	*eq_pos;
+	int		flag;
+
+	flag = 0;//define EXPORT_NOME
+	eq_pos = ft_strchr(*key, '=');
+	if (eq_pos)
+	{
+		if (is_append_flag(key, eq_pos))
+			flag = 2; //define EXPORT_APPEND
+		else
+			flag = 1; //define EXPORT_NEW
+	}
+	split_args = ft_split(*key, '=');
+	if (!is_valid_var(split_args[0]))
+	{
+		//free split_args
+		print_invalid_identifier(*key);
+		return (4); //define EXPORT_ERROR
+	}
+	//free split_args
+	return (flag); 
+}
+
+int	add_var_to_env(char **args, t_env *envp)
 {
 	int	i;
-	int	j;
-	char	*equal_pos;
-	bool	append_flag;
-	char	**split_args;
-
+	char	*eq_pos;
+	int	flag;
+	int	exit_status;
+//	bool	append_flag;
+//	char	**split_args;
+	exit_status = 0;
 	i = 0;
-	while (strs[++i])
+	while (args[++i])
 	{
-		append_flag = 0;
-		split_args = ft_split(strs[i], '=');
-		if (!is_valid_var(split_args[0]) || *equal_pos == strs[i][0])
+//		flag = -1;
+//		eq_pos = ft_strchr(args[i], '=');
+		flag = which_update_flag(&args[i]);
+		if (flag == 4)
+			exit_status = 1;
+//		if (is_append_flag(&args[i], eq_pos))
+//			append_flag = 1;
+//		split_args = ft_split(args[i], '=');
+//		if (!is_valid_var(split_args[0]) || *eq_pos == args[i][0])
+//		{
+//			print_invalid_identifier(args[i]);
+//			continue ;	
+//		}
+//		if (eq_pos && is_valid_var(split_args[0]))
+		if (flag & 1 || flag & 2)
 		{
-			print_invalid_identifier(strs[i++]);
-			continue ;	
+//			if (!update_env_var(args[i], envp, append_flag))
+			if (!update_env_var(args[i], envp, flag))
+				push_new_env_var(args[i], envp);
 		}
-		equal_pos = ft_strchr(strs[i], '=');
-		if (equal_pos)
-		{
-			if (*equal_pos != strs[i][0] && *(equal_pos - 1) == '+' && strs[i][0] != '+') // cut is_append_env
-			{
-				*(equal_pos - 1) = '\0';
-				strs[i] = ft_strjoin(strs[i], equal_pos); //free strs[i]
-				append_flag = 1;
-			}
-			j = -1;
-			while (envp[++j])
-			{
-				if (update_env_var(strs[i], envp, j, append_flag))
-					break ;
-			}
-			if (envp[j] == NULL)
-			{
-				envp[j] = strs[i];
-				envp[j + 1] = NULL;
-			}
-		}
+//		else
+//			print_invalid_identifier(args[i]);
 	}
+	return (exit_status);
 }
 
 //add_var_to_env
-//while strs[idx]
+//while args[idx]
 //	split delimi =
 //	if !is_valid_split[0]
 //		print error and set_error_status 1, but continue
@@ -122,41 +174,41 @@ void	add_var_to_env(char **strs, char **envp)
 //			env[i + 1] == NULL
 //	idx++
 
-void	print_prefix_env(char *envp[])
+void	print_prefix_env(t_env *envp)
 {
-	int	i;
-
-	i = 0;
-	while (envp[i])
+	while (envp)
 	{
-		printf("declare -x %s\n", envp[i++]); //after '=' enclose with a double quotation
+		printf("declare -x %s=\"%s\"\n", envp->key, envp->value);
+		envp = envp->next;
 	}
 }
 
-void	ft_export(char **strs, char *envp[])
+int	ft_export(char **args, t_env *envp)
 {
-	if (strs[1])
+	int	exit_status;
+
+	exit_status = 0;
+	if (args[1])
 	{
-		add_var_to_env(strs, envp);
+		exit_status = add_var_to_env(args, envp);
 	}
 	else
 	{
 		print_prefix_env(envp);
 	}
+	return (exit_status);
 }
 
-int	main(int argc, char **argv, char *envp[])
+int	main(int argc, char **argv)
 {
-	int	i;
-
-	i = 0;
-	ft_export(argv, envp);
+	t_env	*env;
+	int	exit_status;
+	
+	env = create_env();
+	exit_status = ft_export(argv, env);
 	if (argv[1])
-	{
-		while (envp[i])
-		{
-			printf("%s\n", envp[i++]);
-		}
-	}
+		print_env(env);
+	printf("\n");
+	printf("exit_status: %d\n", exit_status);
 	return (0);
 }

--- a/srcs/builtins/ft_export.c
+++ b/srcs/builtins/ft_export.c
@@ -1,0 +1,162 @@
+#include "minishell.h"
+
+bool	is_valid_var(char *str)
+{
+	int	i;
+	
+//	printf("%s\n", str);
+	if (!str)
+		return (false);
+	if (!ft_isalpha(str[0]) && str[0] != '_')
+		return (false);
+	i = 1;
+	while (str[i])
+	{
+		if ((!ft_isalnum(str[i]) && str[i] != '_'))
+			return (false);
+		i++;
+	}
+	return (true);
+}
+
+
+int	update_env_var(char *arg, char *envp[], int j, bool append_flag)
+{
+	char	**split_env;
+	char	*equal_pos;
+	char	**split_args;
+	char	*value;
+
+	split_args = ft_split(arg, '='); // must free
+//	i = -1;
+//	while (envp[i++])
+//	{
+	split_env = ft_split(envp[j], '='); //must free
+	if (ft_strlen(split_args[0]) == ft_strlen(split_env[0])
+		&& ft_strncmp(split_args[0], split_env[0], ft_strlen(split_args[0])) == 0)
+	{
+		if (append_flag)
+		{
+			equal_pos = ft_strchr(arg, '=');
+			value = ft_substr(equal_pos, 1, ft_strlen(equal_pos + 1));
+			envp[j] = ft_strjoin(envp[j], value);
+			free(value);
+			return (1);
+		}
+		else
+		{
+			envp[j] = arg;
+			return (1);
+		}
+	}
+//	}
+	return (0);
+}
+
+void	print_invalid_identifier(char *str)
+{
+	ft_putstr_fd("minishell: export: `", 2);
+	ft_putstr_fd(str, 2);
+	ft_putstr_fd("': not a valid identifier\n", 2);
+}
+
+void	add_var_to_env(char **strs, char **envp)
+{
+	int	i;
+	int	j;
+	char	*equal_pos;
+	bool	append_flag;
+	char	**split_args;
+
+	i = 0;
+	while (strs[++i])
+	{
+		append_flag = 0;
+		split_args = ft_split(strs[i], '=');
+		if (!is_valid_var(split_args[0]) || *equal_pos == strs[i][0])
+		{
+			print_invalid_identifier(strs[i++]);
+			continue ;	
+		}
+		equal_pos = ft_strchr(strs[i], '=');
+		if (equal_pos)
+		{
+			if (*equal_pos != strs[i][0] && *(equal_pos - 1) == '+' && strs[i][0] != '+') // cut is_append_env
+			{
+				*(equal_pos - 1) = '\0';
+				strs[i] = ft_strjoin(strs[i], equal_pos); //free strs[i]
+				append_flag = 1;
+			}
+			j = -1;
+			while (envp[++j])
+			{
+				if (update_env_var(strs[i], envp, j, append_flag))
+					break ;
+			}
+			if (envp[j] == NULL)
+			{
+				envp[j] = strs[i];
+				envp[j + 1] = NULL;
+			}
+		}
+	}
+}
+
+//add_var_to_env
+//while strs[idx]
+//	split delimi =
+//	if !is_valid_split[0]
+//		print error and set_error_status 1, but continue
+//	if exist =
+//		if = prev is +
+//			apeend = 1
+//		while env[i]
+//			if new_name == env[i]_name
+//				if apeend
+//					env[i] = env[i] + new_value
+//				else
+//					env[i] = new_name'='new_value
+//			i++
+//		if (env[i] == NULL)
+//			env[i] = new_name'='new_value
+//			env[i + 1] == NULL
+//	idx++
+
+void	print_prefix_env(char *envp[])
+{
+	int	i;
+
+	i = 0;
+	while (envp[i])
+	{
+		printf("declare -x %s\n", envp[i++]); //after '=' enclose with a double quotation
+	}
+}
+
+void	ft_export(char **strs, char *envp[])
+{
+	if (strs[1])
+	{
+		add_var_to_env(strs, envp);
+	}
+	else
+	{
+		print_prefix_env(envp);
+	}
+}
+
+int	main(int argc, char **argv, char *envp[])
+{
+	int	i;
+
+	i = 0;
+	ft_export(argv, envp);
+	if (argv[1])
+	{
+		while (envp[i])
+		{
+			printf("%s\n", envp[i++]);
+		}
+	}
+	return (0);
+}

--- a/srcs/builtins/ft_unset.c
+++ b/srcs/builtins/ft_unset.c
@@ -1,0 +1,69 @@
+#include "minishell.h"
+
+bool	is_valid_unset_args(char *str)
+{
+	int	i;
+	
+	if (!ft_isalpha(str[0]) && str[0] != '_')
+		return (false);
+	i = 1;
+	while (str[i])
+	{
+		if ((!ft_isalnum(str[i]) && str[i] != '_'))
+			return (false);
+		i++;
+	}
+	return (true);
+}
+
+void	ft_unset(char **strs, char *envp[])
+{
+	int	i;
+	int	j;
+	char	**split_env;
+
+	i = 1;
+	while (strs[i])
+	{
+		if (!is_valid_unset_args(strs[i]))
+		{
+			ft_putstr_fd("minishell: unset: `", 2);
+			ft_putstr_fd(strs[i++], 2);
+			ft_putstr_fd("': not a valid identifier\n", 2);
+			continue ;
+		}
+		j = 0;
+		while (envp[j])
+		{
+			split_env = ft_split(envp[j], '=');
+			if (ft_strlen(strs[i]) == ft_strlen(split_env[0])
+				&& ft_strncmp(strs[i], split_env[0], ft_strlen(strs[i] + 1)) == 0)
+			{
+				while (envp[j])
+				{
+					envp[j] = envp[j + 1];
+					j++;
+				}
+				free(split_env);
+				break ;
+			}
+			free(split_env);
+			j++;
+		}
+		i++;
+	}
+}
+
+int	main(int argc, char **argv, char *envp[])
+{
+	int	i;
+
+	ft_unset(argv, envp);
+	i = 0;
+	printf("\n==env_list==\n%s\n", envp[i++]);
+	while (envp[i])
+	{
+		printf("%s\n", envp[i++]);
+	}
+	return (0);
+}


### PR DESCRIPTION
ft_env、ft_export、ft_unsetをコピーして整形した環境変数の線形リストに対応させました。
テストケースは今の所網羅できていません。(ft_env以外は取り敢えずコマンドライン引数で引数を渡しています) 
いくつかenv.c内の関数を使用しているので、正常に動かすにはヘッダファイルに関数の追加が必要です。