### PR TITLE
[fix] Processing when there is an argument with no value and displaying a variable with no value when there is no argument in export

### DIFF
--- a/env.c
+++ b/env.c
@@ -2,9 +2,9 @@
 
 t_env	*env_last(t_env *env)
 {
-	int	i;
+//	int	i;
 
-	i = 0;
+//	i = 0;
 	if (env == NULL)
 		return (NULL);
 	while (env->next != NULL)
@@ -127,7 +127,8 @@ void	print_env(t_env *env)
 {
 	while (env)
 	{
-		printf("%s=%s\n", env->key, env->value);
+		if (env->value)
+			printf("%s=%s\n", env->key, env->value);
 		env = env->next;
 	}
 }

--- a/srcs/builtins/ft_unset.c
+++ b/srcs/builtins/ft_unset.c
@@ -23,7 +23,7 @@ void	free_env(t_env **env)
 	free((*env)->key);
 	free((*env)->value);
 	free(*env);
-	env = NULL;
+	*env = NULL;
 }
 
 void	print_unset_error(char *msg)
@@ -45,21 +45,16 @@ void	del_and_free_env(char *key)//, t_env *envp)
 	{
 		if (ft_strncmp(cur->key, key, ft_strlen(key)+1) == 0)
 		{
-//			printf("ok1\n");
 			if (prev_env)
 				prev_env->next = cur->next;
 			else if (cur == g_environ)
 				g_environ = cur->next;
 //				envp = cur->next;
-//			printf("ok2n");
 			free_env(&cur);
-			break ;
+			return ;
 		}
-//		printf("ok3\n");
 		prev_env = cur;
-//		printf("ok4\n");
 		cur = cur->next;
-//		printf("ok5\n");
 	}
 }
 


### PR DESCRIPTION
exportのvalue無しの引数の時も追加し、引数なしで実行した時にvalue無し変数も表示するように変更。
envでvalue無しの変数(== NULL, != "\0")を表示しないように変更。
unset、exportのleak修正。