### PR TITLE
[fix] parser and expansion

### DIFF
--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -84,6 +84,7 @@ typedef struct s_cmd			t_cmd;
 struct s_cmd
 {
 	//int	flag;
+	char		*cmdstr;
 	char		**cmd;
 	t_redirect	*redirect_in;
 	t_redirect	*redirect_out;
@@ -129,6 +130,7 @@ t_node	*parse(t_token *tok, bool *heredoc_err);
 void	print_node(t_node *node, int tab_n);
 void	free_node(t_node *node);
 void	free_token(t_token *tok);
+size_t	cmd_len(t_token *tok);
 
 // srcs/lexer
 t_token	*lexer(char *line);

--- a/srcs/execution/execute.c
+++ b/srcs/execution/execute.c
@@ -278,7 +278,7 @@ void	exec_others(t_cmd *cmd)
 	char	**envstr;
 	char	*path;
 
-	printf("ok\n");
+//	printf("ok\n");
 	envstr = envlist_to_str(g_environ);
 	if (is_path(cmd->cmd[0]))
 	{

--- a/srcs/parser/parse.c
+++ b/srcs/parser/parse.c
@@ -258,13 +258,18 @@ t_node	*parse_simple_cmd(t_token **tok, t_node *node, int *err, int *heredoc)
 		}
 		else
 		{
-			node->cmd->cmd[i] = ft_substr((*tok)->str, 0, (*tok)->len);
-			if (node->cmd->cmd[i++] == NULL)
+			if (node->cmd->cmdstr[0] != '\0')
+				node->cmd->cmdstr = ft_joinfree(node->cmd->cmdstr, ft_strdup(" "));
+			node->cmd->cmdstr = ft_joinfree(node->cmd->cmdstr, ft_substr((*tok)->str, 0, (*tok)->len));
+//			node->cmd->cmd[i] = ft_substr((*tok)->str, 0, (*tok)->len);
+//			if (node->cmd->cmd[i++] == NULL)
+			if (node->cmd->cmdstr == NULL)
 				err_exit("malloc error: ");
 			*tok = (*tok)->next;
 		}
 	}
-	node->cmd->cmd[i] = NULL;
+//	printf("%s\n", node->cmd->cmdstr);
+//	node->cmd->cmd[i] = NULL;
 	return (node);
 }
 
@@ -277,8 +282,10 @@ t_node	*parse_cmd(t_token **tok, int *error_flag, int *heredoc_flag)
 		return (NULL);
 	t = *tok;
 	node = new_node(ND_COMMAND);
-	node->cmd->cmd = (char **)ft_calloc(sizeof(char *), (cmd_len(*tok) + 1));
-	if (node->cmd->cmd == NULL)
+	node->cmd->cmdstr = ft_strdup("");
+//	node->cmd->cmd = (char **)ft_calloc(sizeof(char *), (cmd_len(*tok) + 1));
+//	if (node->cmd->cmd == NULL)
+	if (node->cmd->cmdstr == NULL)
 	{
 		err_exit("malloc error: ");
 	}


### PR DESCRIPTION
parerとexpansionを修正して export a=" " の後 echo$a-a や cat < main.c$a (success) 、cat < main.c$a-a (ambiguous redirect)などのパターンに対応させました。